### PR TITLE
Small update on scripts/inference-dev

### DIFF
--- a/scripts/inference-dev
+++ b/scripts/inference-dev
@@ -28,7 +28,7 @@ distDir="$cfiDir"/dist
 
 jdkPaths="${cfDir}"/jdk/annotated
 
-CFBuildDirs="${langtoolsDir}/build/classes":"${annoToolsDir}"/scene-lib/bin:"${cfDir}"/dataflow/build:"${cfDir}"/javacutil/build:"${cfDir}"/stubparser/build:"${cfDir}"/framework/build:"${cfDir}"/checker/build
+CFBuildDirs="${langtoolsDir}"/build/classes:"${annoToolsDir}"/scene-lib/bin:"${cfDir}"/dataflow/build:"${cfDir}"/javacutil/build:"${cfDir}"/stubparser/build:"${cfDir}"/framework/build:"${cfDir}"/checker/build
 CFIBuildDirs="${cfiDir}/bin"
 
 SAT4jJars="${distDir}"/org.ow2.sat4j.core-2.3.4.jar:"${distDir}"/org.ow2.sat4j.maxsat-2.3.4.jar:"${distDir}"/org.ow2.sat4j.pb-2.3.4.jar

--- a/scripts/inference-dev
+++ b/scripts/inference-dev
@@ -19,6 +19,7 @@ fi
 
 ROOT=$(cd ${myDir}/../../ && pwd)
 
+langtoolsDir="$ROOT"/jsr308-langtools
 annoToolsDir="$ROOT"/annotation-tools
 cfDir="$ROOT"/checker-framework
 cfiDir="$ROOT"/checker-framework-inference
@@ -27,7 +28,7 @@ distDir="$cfiDir"/dist
 
 jdkPaths="${cfDir}"/jdk/annotated
 
-CFBuildDirs="${annoToolsDir}"/scene-lib/bin:"${cfDir}"/dataflow/build:"${cfDir}"/javacutil/build:"${cfDir}"/stubparser/build:"${cfDir}"/framework/build:"${cfDir}"/checker/build
+CFBuildDirs="${langtoolsDir}/build/classes":"${annoToolsDir}"/scene-lib/bin:"${cfDir}"/dataflow/build:"${cfDir}"/javacutil/build:"${cfDir}"/stubparser/build:"${cfDir}"/framework/build:"${cfDir}"/checker/build
 CFIBuildDirs="${cfiDir}/bin"
 
 SAT4jJars="${distDir}"/org.ow2.sat4j.core-2.3.4.jar:"${distDir}"/org.ow2.sat4j.maxsat-2.3.4.jar:"${distDir}"/org.ow2.sat4j.pb-2.3.4.jar


### PR DESCRIPTION
add jsr308-langtools build classes to classpath. Now we can also use eclipse output of jsr308-langtools when debugging.