### PR TITLE
Prints CombineConstraint in a nicer way

### DIFF
--- a/src/checkers/inference/model/serialization/ToStringSerializer.java
+++ b/src/checkers/inference/model/serialization/ToStringSerializer.java
@@ -155,8 +155,10 @@ public class ToStringSerializer implements Serializer<String, String> {
     public String serialize(CombineConstraint constraint) {
         boolean prevShowVerboseVars = showVerboseVars;
         showVerboseVars = false;
+        // "\u25B7" is viewpoint adaptation sign ▷
         String result = indent(constraint.getResult().serialize(this) + " = ( "
-                + constraint.getDeclared().serialize(this) + " + " + constraint.getTarget() + " )");
+                + constraint.getTarget().serialize(this) + " \u25B7 "
+                + constraint.getDeclared().serialize(this) + " )");
         showVerboseVars = prevShowVerboseVars;
         return result;
     }


### PR DESCRIPTION
1. For CombineConstraint, print result as:
1 = 2 ▷ 3 
Old way of printing is confusing : 1 = 3 + 2, in which 2 is the receiver, and the "+" sign seems not vivid.